### PR TITLE
add a sourceLink field to IndexStoredTemplateMetadata

### DIFF
--- a/common/src/test/scala/activator/cache/MetadataTest.scala
+++ b/common/src/test/scala/activator/cache/MetadataTest.scala
@@ -8,7 +8,8 @@ class MetadataTest {
   @Test
   def cleanupAuthorDefined(): Unit = {
     val cleaned = AuthorDefinedTemplateMetadata(name = "foo", title = "bar", description = "baz\nblah",
-      authorName = Some("blah"), authorLink = Some("http://example.com/"), tags = Seq("a", "b"), templateTemplate = false)
+      authorName = Some("blah"), authorLink = Some("http://example.com/"), tags = Seq("a", "b"), templateTemplate = false,
+      sourceLink = Some("http://example.com/source"))
     val dirty = AuthorDefinedTemplateMetadata(name = cleaned.name + " ",
       title = "\n" + cleaned.title,
       description = cleaned.description.flatMap {
@@ -17,7 +18,8 @@ class MetadataTest {
       },
       authorName = cleaned.authorName.map(_ + " "),
       authorLink = cleaned.authorLink.map(" " + _),
-      tags = cleaned.tags.map(" " + _), templateTemplate = cleaned.templateTemplate)
+      tags = cleaned.tags.map(" " + _), templateTemplate = cleaned.templateTemplate,
+      sourceLink = cleaned.sourceLink.map(" " + _))
     assertEquals(cleaned, dirty.cleanup())
   }
 
@@ -26,12 +28,14 @@ class MetadataTest {
     // Some(null) and Seq(null) are just twisted and not really expected,
     // but the validate routine handles them anyway
     val broken = AuthorDefinedTemplateMetadata(name = null, title = null, description = null,
-      authorName = Some(null), authorLink = Some(null), tags = Seq(null), templateTemplate = false)
+      authorName = Some(null), authorLink = Some(null), tags = Seq(null), templateTemplate = false,
+      sourceLink = Some(null))
     val result = broken.validate()
     assertEquals(
       ProcessFailure(Seq(ProcessError("Missing field 'name'", None), ProcessError("Missing field 'title'", None),
         ProcessError("Missing field 'description'", None), ProcessError("Missing field 'authorLink'", None),
-        ProcessError("Missing field 'authorName'", None), ProcessError("Missing field 'tags'", None))),
+        ProcessError("Missing field 'authorName'", None), ProcessError("Missing field 'tags'", None),
+        ProcessError("Missing field 'sourceLink'", None))),
       result)
   }
 
@@ -43,7 +47,8 @@ class MetadataTest {
       authorName = Some(""), // empty string
       authorLink = Some("a^%"), // not a valid link
       tags = Seq("a b", "^%@#", "foo_bar", ""), // invalid stuff in tags
-      templateTemplate = false)
+      templateTemplate = false,
+      sourceLink = Some("$@"))
     val result = broken.cleanup().validate()
     assertEquals(
       ProcessFailure(Seq(ProcessError("name contains invalid control characters (maybe a newline)", None),
@@ -62,7 +67,8 @@ class MetadataTest {
   @Test
   def validateUrlUnfriendlyNames(): Unit = {
     val base = AuthorDefinedTemplateMetadata(name = "foo", title = "bar", description = "baz\nblah",
-      authorName = Some("blah"), authorLink = Some("http://example.com/"), tags = Seq("a", "b"), templateTemplate = false)
+      authorName = Some("blah"), authorLink = Some("http://example.com/"), tags = Seq("a", "b"), templateTemplate = false,
+      sourceLink = Some("http://example.com/source/"))
     assertEquals("base is valid", ProcessSuccess(base), base.validate())
 
     for (c <- Seq('/', ' ', '%')) {

--- a/templates-cache/src/main/scala/activator/cache/LuceneIndex.scala
+++ b/templates-cache/src/main/scala/activator/cache/LuceneIndex.scala
@@ -66,6 +66,7 @@ object LuceneIndex {
   val FIELD_AUTHOR_NAME = "authorName"
   val FIELD_AUTHOR_LINK = "authorLink"
   val FIELD_TEMPLATE_TEMPLATE = "templateTemplate"
+  val FIELD_SOURCE_LINK = "sourceLink"
 
   val FIELD_TRUE_VALUE = "true"
   val FIELD_FALSE_VALUE = "false"
@@ -94,6 +95,8 @@ object LuceneIndex {
     }
     val featured = (doc get FIELD_FEATURED) == FIELD_TRUE_VALUE
     val templateTemplate = (doc get FIELD_TEMPLATE_TEMPLATE) == FIELD_TRUE_VALUE
+    // sourceLink may not be present in old indexes
+    val sourceLink = Option(doc get FIELD_SOURCE_LINK)
 
     //val
     IndexStoredTemplateMetadata(
@@ -107,7 +110,10 @@ object LuceneIndex {
       timeStamp = ts,
       featured = featured,
       usageCount = usageCount,
-      templateTemplate = templateTemplate)
+      templateTemplate = templateTemplate,
+      // this getOrElse is just to deal with old records without exploding;
+      // newly-published templates will always have the source link
+      sourceLink = sourceLink.getOrElse("http://typesafe.com/"))
   }
 
   def metadataToDocument(metadata: IndexStoredTemplateMetadata): Document = {
@@ -123,6 +129,7 @@ object LuceneIndex {
     doc.add(new StringField(FIELD_FEATURED, booleanToString(metadata.featured), Field.Store.YES))
     doc.add(new StringField(FIELD_USAGE_COUNT, usageToString(metadata.usageCount), Field.Store.YES))
     doc.add(new StringField(FIELD_TEMPLATE_TEMPLATE, booleanToString(metadata.templateTemplate), Field.Store.YES))
+    doc.add(new StringField(FIELD_SOURCE_LINK, metadata.sourceLink, Field.Store.YES))
     doc
   }
 

--- a/templates-cache/src/test/scala/activator/cache/ActionsTest.scala
+++ b/templates-cache/src/test/scala/activator/cache/ActionsTest.scala
@@ -30,7 +30,8 @@ class ActionsTest {
       timeStamp = 1L,
       featured = true,
       usageCount = None,
-      templateTemplate = true)
+      templateTemplate = true,
+      sourceLink = "http://example.com/source")
 
     val metadataFile = new java.io.File(dir, Constants.METADATA_FILENAME)
 

--- a/templates-cache/src/test/scala/activator/cache/DefaultTemplateCacheTest.scala
+++ b/templates-cache/src/test/scala/activator/cache/DefaultTemplateCacheTest.scala
@@ -103,7 +103,8 @@ class DefaultTemplateCacheTest {
       authorName = "Bob",
       authorLink = "http://example.com/bob",
       tags = Seq("test", "template"),
-      templateTemplate = true),
+      templateTemplate = true,
+      sourceLink = "http://example.com/source"),
     locallyCached = true)
 
   val nonLocalTemplate = TemplateMetadata(
@@ -118,7 +119,8 @@ class DefaultTemplateCacheTest {
       authorName = "Jim",
       authorLink = "http://example.com/jim",
       tags = Seq("test", "template"),
-      templateTemplate = false),
+      templateTemplate = false,
+      sourceLink = "http://example.com/source"),
     locallyCached = false)
   def makeTestCache(dir: File): Unit = {
     val writer = LuceneIndexProvider.write(new File(dir, Constants.METADATA_INDEX_FILENAME))

--- a/templates-cache/src/test/scala/activator/cache/IndexDbTest.scala
+++ b/templates-cache/src/test/scala/activator/cache/IndexDbTest.scala
@@ -67,7 +67,8 @@ trait IndexDbTest {
       timeStamp = 1L,
       featured = true,
       usageCount = None,
-      templateTemplate = true),
+      templateTemplate = true,
+      sourceLink = "http://example.com/source"),
       IndexStoredTemplateMetadata(
         id = "ID-2",
         name = "url-friendly-name-2",
@@ -79,7 +80,8 @@ trait IndexDbTest {
         timeStamp = 1L,
         featured = false,
         usageCount = None,
-        templateTemplate = false))
+        templateTemplate = false,
+        sourceLink = "http://example.com/source"))
 
   @Before
   def preStart(): Unit = {

--- a/templates-cache/src/test/scala/activator/cache/OfflineDefaultTemplateCacheTest.scala
+++ b/templates-cache/src/test/scala/activator/cache/OfflineDefaultTemplateCacheTest.scala
@@ -53,7 +53,8 @@ class OfflineDefaultTemplateCacheTest {
       authorName = "Bob",
       authorLink = "http://example.com/bob",
       tags = Seq("test", "template"),
-      templateTemplate = true),
+      templateTemplate = true,
+      sourceLink = "http://example.com/source"),
     locallyCached = true)
 
   val nonLocalTemplate = TemplateMetadata(
@@ -68,7 +69,8 @@ class OfflineDefaultTemplateCacheTest {
       authorName = "Jim",
       authorLink = "http://example.com/jim",
       tags = Seq("test", "template"),
-      templateTemplate = true),
+      templateTemplate = true,
+      sourceLink = "http://example.com/source"),
     locallyCached = false)
   def makeTestCache(dir: File): Unit = {
     val writer = LuceneIndexProvider.write(new File(dir, Constants.METADATA_INDEX_FILENAME))

--- a/templates-cache/src/test/scala/activator/cache/RemoteTemplateStubTest.scala
+++ b/templates-cache/src/test/scala/activator/cache/RemoteTemplateStubTest.scala
@@ -171,7 +171,8 @@ class RemoteTemplateStubTest {
       authorName = "Jim Bob",
       authorLink = "http://example.com/jimbob/",
       tags = Seq("test", "template"),
-      templateTemplate = false),
+      templateTemplate = false,
+      sourceLink = "http://example.com/source"),
     locallyCached = true)
 
   val nonLocalTemplate = TemplateMetadata(
@@ -186,7 +187,8 @@ class RemoteTemplateStubTest {
       authorName = "Jim Bob",
       authorLink = "http://example.com/jimbob/",
       tags = Seq("test", "template"),
-      templateTemplate = true),
+      templateTemplate = true,
+      sourceLink = "http://example.com/source"),
     locallyCached = false)
 
   val resolvedNonLocalTemplate =
@@ -204,7 +206,8 @@ class RemoteTemplateStubTest {
       authorName = "Jim Bob",
       authorLink = "http://example.com/jimbob/",
       tags = Seq("test", "template"),
-      templateTemplate = false),
+      templateTemplate = false,
+      sourceLink = "http://example.com/source"),
     locallyCached = false)
 
   val resolvedNewNonLocalTemplate =


### PR DESCRIPTION
and store it in the cache.

If it isn't found (in an old cache entry) we just use a bogus
value of http://typesafe.com/ - after all templates are
republished this should not ever happen.
