### PR TITLE
Split repo generation from major version of index format

### DIFF
--- a/templates-cache/src/main/scala/activator/cache/CacheProperties.scala
+++ b/templates-cache/src/main/scala/activator/cache/CacheProperties.scala
@@ -22,6 +22,13 @@ class CacheProperties(location: java.io.File) {
     props.setProperty(Constants.CACHE_HASH_PROPERTY, newId)
   }
 
+  def cacheIndexBinaryMajorVersion =
+    // default to 0 because the original binary version was 0 but we didn't write it to the properties file
+    // at first
+    Option(props.getProperty(Constants.CACHE_INDEX_MAJOR_VERSION_PROPERTY)) map (_.toInt) getOrElse 0
+  def cacheIndexBinaryMajorVersion_=(version: Int) =
+    props.setProperty(Constants.CACHE_INDEX_MAJOR_VERSION_PROPERTY, version.toString)
+
   def cacheIndexBinaryIncrementVersion =
     props.getProperty(Constants.CACHE_INDEX_INCREMENT_VERSION_PROPERTY).toInt
   def cacheIndexBinaryIncrementVersion_=(version: Int) =
@@ -48,6 +55,7 @@ object CacheProperties {
   def write(file: File, serial: Long, hash: String): ProcessResult[File] =
     Validating.withMsg("Unable to create new cache properties.") {
       val props = new CacheProperties(file)
+      props.cacheIndexBinaryMajorVersion = Constants.INDEX_BINARY_MAJOR_VERSION
       props.cacheIndexBinaryIncrementVersion = Constants.INDEX_BINARY_INCREMENT_VERSION
       props.cacheIndexHash = hash
       props.cacheIndexSerial = serial

--- a/templates-cache/src/main/scala/activator/cache/Constants.scala
+++ b/templates-cache/src/main/scala/activator/cache/Constants.scala
@@ -8,18 +8,45 @@ object Constants {
   val TUTORIAL_DIR = "tutorial"
 
   val CACHE_HASH_PROPERTY = "cache.hash"
+  val CACHE_INDEX_MAJOR_VERSION_PROPERTY = "cache.binary.major.version"
   val CACHE_INDEX_INCREMENT_VERSION_PROPERTY = "cache.binary.increment.version"
   val CACHE_SERIAL_PROPERTY = "cache.serial"
 
   // Property name that goes in <local-project>/build.properties upon a clone.
   val TEMPLATE_UUID_PROPERTY_NAME = "template.uuid"
 
-  // This number represents the current binary version of the Index database.
-  // Any index published with this version should be readable by previous releases of the software,
-  // i.e. only binary additions, no removals.
-  val INDEX_BINARY_VERSION = "1"
-  // This number represents the current number of additions to the Index database.
-  // When resolving new repositories, we must ensure that the version we're downloaded
-  // has its increment version > than our software's so that we can find all the features we require.
+  // This number is included in repository filenames. i.e. it controls
+  // where we look for and upload indexes.
+  // If this is incremented, older versions of the software will not
+  // see new indexes with the new version, they will only see old indexes.
+  // We will only consume and generate new indexes with this new number.
+  // This number does not necessarily change the index *format*, though.
+  // We may bump this even when the format is unchanged if we want to
+  // keep old clients from seeing new indexes, for example we are bumping
+  // this in the sbt 0.12 -> 0.13 transition.
+  // INDEX_BINARY_MAJOR_VERSION below represents a breaking change in *format*.
+  val INDEX_REPOSITORY_GENERATION = "1"
+
+  // this number is stored in the index itself and must MATCH EXACTLY
+  // what the consumer of the index expects; that is, bumping it causes
+  // new versions of the software to reject all previous indexes, and
+  // causes previous versions of the software to reject all new indexes.
+  // If you increment this you MUST also increment INDEX_REPOSITORY_GENERATION,
+  // above, or we will put incompatible indexes where old clients will find
+  // them.
+  // If INDEX_REPOSITORY_GENERATION is incremented then in theory
+  // mismatches in this version would never happen, but this is here
+  // just as an extra check.
+  // The first generation of indexes, by the way, did not store this
+  // field, so if not present it should be assumed to be 0.
+  val INDEX_BINARY_MAJOR_VERSION = 0
+
+  // This number is stored in the index itself and indicates the MINIMUM
+  // increment version we require. So incrementing this means that we will
+  // consume only indexes generated with the new, higher number; but we will create
+  // indexes that older versions can still consume. This number assumes that
+  // all changes are backward-compatible (do not break old) but that new versions
+  // require the latest format and cannot handle an older one. If new versions can
+  // still use the old index format, there's no need to increment this.
   val INDEX_BINARY_INCREMENT_VERSION = 0
 }

--- a/templates-cache/src/main/scala/activator/templates/repository/Layout.scala
+++ b/templates-cache/src/main/scala/activator/templates/repository/Layout.scala
@@ -31,7 +31,7 @@ object Layout {
   }
 
   def indexDirectory(baseRepo: URI): URI =
-    baseRepo / INDEXES_DIRECTORY_NAME / versionNumber(Constants.INDEX_BINARY_VERSION)
+    baseRepo / INDEXES_DIRECTORY_NAME / versionNumber(Constants.INDEX_REPOSITORY_GENERATION)
   def currentIndexTagUri(baseRepo: URI): URI =
     indexDirectory(baseRepo) / CURRENT_INDEX_TAG_FILE
   def indexUri(baseRepo: URI, hash: String): URI =

--- a/templates-cache/src/main/scala/activator/templates/repository/UriRemoteTemplateRepository.scala
+++ b/templates-cache/src/main/scala/activator/templates/repository/UriRemoteTemplateRepository.scala
@@ -75,7 +75,8 @@ class UriRemoteTemplateRepository(base: URI, log: LoggingAdapter) extends Remote
         val indexProps = new File(tmpDir, "index.properties")
         resolveIndexProperties(indexProps)
         val props = new CacheProperties(indexProps)
-        def recentEnough = props.cacheIndexBinaryIncrementVersion >= Constants.INDEX_BINARY_INCREMENT_VERSION
+        def recentEnough = props.cacheIndexBinaryMajorVersion == Constants.INDEX_BINARY_MAJOR_VERSION &&
+          props.cacheIndexBinaryIncrementVersion >= Constants.INDEX_BINARY_INCREMENT_VERSION
         def differentCache = props.cacheIndexHash != currentHash
         differentCache && recentEnough
       }


### PR DESCRIPTION
This makes the code easier to understand, if nothing else,
though in principle we could rely on repo generation alone.
The major version check is just extra paranoia.
