### PR TITLE
Apply ZipHelper fix for Windows from sbt-native-packager

### DIFF
--- a/common/src/main/scala/activator/ZipHelper.scala
+++ b/common/src/main/scala/activator/ZipHelper.scala
@@ -31,6 +31,18 @@ object ZipHelper {
       } yield FileMapping(file, name, Some(perm))
     archive(mappings, outputZip)
   }
+  /**
+   * Replaces windows backslash file separator with a forward slash, this ensures the zip file entry is correct for
+   * any system it is extracted on.
+   * @param path  The path of the file in the zip file
+   */
+  private def normalizePath(path: String) = {
+    val sep = java.io.File.separatorChar
+    if (sep == '/')
+      path
+    else
+      path.replace(sep, '/')
+  }
 
   private def archive(sources: Seq[FileMapping], outputFile: File): Unit = {
     if (outputFile.isDirectory) sys.error("Specified output file " + outputFile + " is a directory.")
@@ -39,7 +51,7 @@ object ZipHelper {
       outputDir.mkdirs
       withZipOutput(outputFile) { output =>
         for (FileMapping(file, name, mode) <- sources; if !file.isDirectory) {
-          val entry = new ZipArchiveEntry(file, name)
+          val entry = new ZipArchiveEntry(file, normalizePath(name))
           // Now check to see if we have permissions for this sucker.
           mode foreach (entry.setUnixMode)
           output putArchiveEntry entry


### PR DESCRIPTION
This isn't important for where we use ZipHelper now (on our server),
but in case we use it sometime in the client it might matter.
