### PR TITLE
API change to save name that goes with validated UUIDs

### DIFF
--- a/common/src/main/scala/activator/storage/Storage.scala
+++ b/common/src/main/scala/activator/storage/Storage.scala
@@ -69,6 +69,10 @@ object InstanceValidatedWithOptionalName {
       Some(InstanceValidatedWithOptionalName(UUID.fromString(key), m.getAs[String]("name")))
     }
   }
+
+  implicit object InstanceValidatedWithOptionalNameKeyExtractor extends KeyExtractor[InstanceValidatedWithOptionalName] {
+    override def getKey(t: InstanceValidatedWithOptionalName): String = t.uuid.toString
+  }
 }
 
 object InstanceStatus {


### PR DESCRIPTION
Right now we don't keep around the name except for the currently-indexed uuids (latest versions).
