### PR TITLE
add templateZipURI method to cache

### DIFF
--- a/templates-cache/src/main/scala/activator/cache/DefaultTemplateCache.scala
+++ b/templates-cache/src/main/scala/activator/cache/DefaultTemplateCache.scala
@@ -82,6 +82,9 @@ object DefaultTemplateCache {
       templateName: String): Boolean =
       sys.error("Offline mode! can't get template bundle")
 
+    def templateZipURI(uuid: UUID): URI =
+      sys.error("Offline mode! can't get template zip")
+
     def resolveMinimalActivatorDist(toFile: File, activatorVersion: String): File =
       sys.error("Offline mode! Can't get minimal activator dist")
   }

--- a/templates-cache/src/main/scala/activator/cache/RemoteTemplateRepository.scala
+++ b/templates-cache/src/main/scala/activator/cache/RemoteTemplateRepository.scala
@@ -46,6 +46,13 @@ trait RemoteTemplateRepository {
     templateName: String): URI
 
   /**
+   * Calculates the URI where we would find or publish the main
+   * template zip ... normally you want to use this via the cache,
+   * not directly, though.
+   */
+  def templateZipURI(uuid: UUID): URI
+
+  /**
    * Checks whether the bundled version of the template exists.
    */
   def templateBundleExists(activatorVersion: String,

--- a/templates-cache/src/main/scala/activator/templates/repository/UriRemoteTemplateRepository.scala
+++ b/templates-cache/src/main/scala/activator/templates/repository/UriRemoteTemplateRepository.scala
@@ -219,4 +219,7 @@ class UriRemoteTemplateRepository(base: URI, log: LoggingAdapter) extends Remote
     uuid: UUID,
     templateName: String): Boolean =
     existsTryingS3First(templateBundleURI(activatorVersion, uuid, templateName))
+
+  override def templateZipURI(uuid: UUID): URI =
+    layout.template(uuid.toString)
 }

--- a/templates-cache/src/test/scala/activator/cache/RemoteTemplateStubTest.scala
+++ b/templates-cache/src/test/scala/activator/cache/RemoteTemplateStubTest.scala
@@ -62,6 +62,8 @@ class RemoteTemplateStubTest {
       uuid: UUID,
       templateName: String): Boolean = ???
 
+    def templateZipURI(uuid: UUID): URI = ???
+
     def resolveMinimalActivatorDist(toFile: File, activatorVersion: String): File = ???
   }
 


### PR DESCRIPTION
This is sort of an implementation detail but it's useful to put the
logic for munging the tutorial on typesafe.com so all the HTML
presentation is on typesafe.com. So we want to get the raw zip.
We don't want typesafe.com to directly use a template cache.
