### PR TITLE
Support for local templates

### DIFF
--- a/common/src/main/scala/activator/OptionalProperty.scala
+++ b/common/src/main/scala/activator/OptionalProperty.scala
@@ -1,0 +1,16 @@
+package activator
+
+import java.util.Properties
+
+class OptionalProperty(name: String, properties: Properties) {
+  def value: Option[String] = Option(properties.getProperty(name))
+  def value_=(value: Option[String]): Unit = {
+    if (properties.containsKey(name)) properties.remove(name)
+    value.foreach(properties.setProperty(name, _))
+  }
+}
+
+object OptionalProperty {
+  def apply(name: String, properties: Properties) =
+    new OptionalProperty(name, properties)
+}

--- a/common/src/main/scala/activator/Property.scala
+++ b/common/src/main/scala/activator/Property.scala
@@ -1,0 +1,14 @@
+package activator
+
+import java.util.Properties
+
+class Property(name: String, properties: Properties) {
+  def value: String = properties.getProperty(name)
+  def value_=(v: String): Unit = {
+    properties.setProperty(name, v)
+  }
+}
+
+object Property {
+  def apply(name: String, properties: Properties): Property = new Property(name, properties)
+}

--- a/common/src/main/scala/activator/cache/TemplateMetadata.scala
+++ b/common/src/main/scala/activator/cache/TemplateMetadata.scala
@@ -5,8 +5,11 @@ package activator
 package cache
 
 import java.net.URISyntaxException
+
 import scala.concurrent.Future
 import java.net.URLEncoder
+import java.util.Properties
+
 import scala.concurrent.ExecutionContext
 
 /**
@@ -146,10 +149,53 @@ case class AuthorDefinedTemplateMetadata(
     else
       ProcessFailure(errors.map(ProcessError(_)))
   }
+
+  def toProperties: Properties = {
+    import activator.cache.{ AuthorDefinedTemplateMetadata => p }
+    implicit val properties = new Properties()
+
+    p.authorName.value = authorName
+    p.authorTwitter.value = authorTwitter
+    p.authorBio.value = authorBio
+    p.authorLogo.value = authorLogo
+    p.authorLink.value = authorLink
+    p.description.value = description
+    p.name.value = name
+    p.sourceLink.value = sourceLink
+    p.title.value = title
+    p.tags.value = tags.mkString(",")
+
+    properties
+  }
 }
 
 object AuthorDefinedTemplateMetadata {
+  private def name(implicit properties: Properties) = Property("name", properties)
+  private def title(implicit properties: Properties) = Property("title", properties)
+  private def description(implicit properties: Properties) = Property("description", properties)
+  private def authorName(implicit properties: Properties) = OptionalProperty("authorName", properties)
+  private def authorLink(implicit properties: Properties) = OptionalProperty("authorLink", properties)
+  private def tags(implicit properties: Properties) = Property("tags", properties)
+  private def sourceLink(implicit properties: Properties) = OptionalProperty("sourceLink", properties)
+  private def authorLogo(implicit properties: Properties) = OptionalProperty("authorLogo", properties)
+  private def authorBio(implicit properties: Properties) = OptionalProperty("authorBio", properties)
+  private def authorTwitter(implicit properties: Properties) = OptionalProperty("authorTwitter", properties)
 
+  def fromProperties(properties: Properties): AuthorDefinedTemplateMetadata = {
+    implicit val p = properties
+    AuthorDefinedTemplateMetadata(
+      name = name.value,
+      title = title.value,
+      description = description.value,
+      authorName = authorName.value,
+      authorLink = authorLink.value,
+      tags = tags.value.split(','),
+      templateTemplate = false,
+      sourceLink = sourceLink.value,
+      authorLogo = authorLogo.value,
+      authorBio = authorBio.value,
+      authorTwitter = authorTwitter.value)
+  }
 }
 
 /**

--- a/templates-cache/src/main/scala/activator/cache/TemplateCacheActor.scala
+++ b/templates-cache/src/main/scala/activator/cache/TemplateCacheActor.scala
@@ -180,15 +180,19 @@ class TemplateCacheActor(provider: IndexDbProvider, location: File, remote: Remo
         templates.exists {
           case (_, templateMetadata) =>
             index.templateByName(templateMetadata.name) exists { indexedTemplate =>
-              val different =
+              val mergedTemplateInfo: IndexStoredTemplateMetadata =
                 templateMetadata.copy(
                   id = indexedTemplate.id,
                   timeStamp = indexedTemplate.timeStamp,
-                  creationTime = indexedTemplate.creationTime
-                ) != indexedTemplate
-              if(different) {
-                log.debug(s"Template needs to be re indexed ${templateMetadata.name}")
-                log.debug(s"Template $templateMetadata")
+                  creationTime = indexedTemplate.creationTime,
+                  featured = indexedTemplate.featured,
+                  usageCount = indexedTemplate.usageCount,
+                  templateTemplate = indexedTemplate.templateTemplate,
+                  category = indexedTemplate.category)
+              val different = mergedTemplateInfo != indexedTemplate
+              if (different) {
+                log.debug(s"Template needs to be re indexed ${mergedTemplateInfo.name}")
+                log.debug(s"Template $mergedTemplateInfo")
                 log.debug(s"Indexed Template $indexedTemplate")
               }
               different

--- a/templates-cache/src/main/scala/activator/cache/TemplateCacheActor.scala
+++ b/templates-cache/src/main/scala/activator/cache/TemplateCacheActor.scala
@@ -146,14 +146,14 @@ class TemplateCacheActor(provider: IndexDbProvider, location: File, remote: Remo
     try {
       val templates: Array[(File, IndexStoredTemplateMetadata)] =
         location.listFiles().flatMap { file =>
-          if (file.isDirectory) file.listFiles(isActivatorProperties) else Nil
+          if (file.isDirectory && index.template(file.getName).isEmpty) file.listFiles(isActivatorProperties) else Nil
         } map { activatorPropertiesFile =>
           val props = new Properties()
           props.load(new FileInputStream(activatorPropertiesFile))
 
           val authorDefinedTemplateMetadata = AuthorDefinedTemplateMetadata.fromProperties(props)
-
           val time: Long = new Date().getTime
+
           (
             activatorPropertiesFile.getParentFile,
             IndexStoredTemplateMetadata(
@@ -173,7 +173,9 @@ class TemplateCacheActor(provider: IndexDbProvider, location: File, remote: Remo
               authorBio = authorDefinedTemplateMetadata.authorBio,
               authorTwitter = authorDefinedTemplateMetadata.authorTwitter,
               category = TemplateMetadata.Category.COMPANY,
-              creationTime = time))
+              creationTime = time
+            )
+          )
         }
 
       val templateNeedsToBeReIndexed: Boolean =

--- a/templates-cache/src/test/scala/activator/cache/DefaultTemplateCacheTest.scala
+++ b/templates-cache/src/test/scala/activator/cache/DefaultTemplateCacheTest.scala
@@ -80,14 +80,7 @@ class DefaultTemplateCacheTest {
 
     try {
       makeTestCache(cacheDir)
-
       resolveNonIndexedTemplate(seedRepository, templateDesc, cacheDir)
-
-      IO delete templateDir
-      IO.createDirectory(templateDir)
-
-      makeTemplateDirectory(templateDir, templateName = "test", description = "test2")
-      resolveNonIndexedTemplate(seedRepository, templateDesc = "test2", cacheDir)
     } finally {
       dirs foreach IO.delete
       system.shutdown()

--- a/templates-cache/src/test/scala/activator/cache/RemoteTemplateStubTest.scala
+++ b/templates-cache/src/test/scala/activator/cache/RemoteTemplateStubTest.scala
@@ -4,84 +4,23 @@
 package activator
 package cache
 
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+import activator.cache.StubRemoteRepository._
+import akka.actor._
 import org.junit.Assert._
 import org.junit._
-import java.io.File
-import akka.actor._
-import concurrent.Await
-import concurrent.duration._
 import sbt.IO
-import java.util.UUID
-import java.net.URI
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 class RemoteTemplateStubTest {
-
-  val FIRST_INDEX_ID = "FIRST INDEX"
-  val SECOND_INDEX_ID = "SECOND INDEX"
-
   var cacheDir: File = null
   var system: ActorSystem = null
   var cache: TemplateCache = null
-  implicit val timeout = akka.util.Timeout(60 * 1000L)
-
-  object StubRemoteRepository extends RemoteTemplateRepository {
-    def resolveIndexProperties(localPropsFile: File): File = {
-      // TODO - implement?
-      localPropsFile
-    }
-    def hasNewIndexProperties(currentHash: String): Boolean =
-      SECOND_INDEX_ID != currentHash
-
-    def resolveLatestIndexHash(): String =
-      SECOND_INDEX_ID
-
-    def ifNewIndexProperties(currentHash: String)(onNewProperties: CacheProperties => Unit): Unit =
-      if (hasNewIndexProperties(currentHash)) {
-        IO.withTemporaryDirectory { tmpDir =>
-          val propsFile = new File(tmpDir, "index.properties")
-          val props = new CacheProperties(propsFile)
-          props.cacheIndexHash = SECOND_INDEX_ID
-          props.save("saved SECOND_INDEX_ID")
-          onNewProperties(props)
-        }
-      }
-
-    // TODO - Actually alter the index and check to see if we have the new one.
-    // Preferable with a new template, not in the existing index.
-    def resolveIndexTo(indexDirOrFile: File, currentHash: String): Unit = {
-      makeIndex(indexDirOrFile)(
-        template1,
-        nonLocalTemplate,
-        newNonLocalTemplate)
-    }
-
-    def resolveTemplateTo(templateId: String, localDir: File): File = {
-      if (nonLocalTemplate.id == templateId || newNonLocalTemplate.id == templateId) {
-        // Fake Resolving a remote template
-        if (!localDir.exists) IO.createDirectory(localDir)
-        IO.write(new File(localDir, "build2.sbt"), """name := "Test2" """)
-        val tutorialDir = new File(localDir, Constants.TUTORIAL_DIR)
-        IO createDirectory tutorialDir
-        IO.write(new File(tutorialDir, "index.html"), "<html></html>")
-      }
-      localDir
-    }
-
-    def templateBundleURI(activatorVersion: String,
-      uuid: UUID,
-      templateName: String): URI = ???
-
-    def templateBundleExists(activatorVersion: String,
-      uuid: UUID,
-      templateName: String): Boolean = ???
-
-    def templateZipURI(uuid: UUID): URI = ???
-
-    def authorLogoURI(uuid: UUID): URI = ???
-
-    def resolveMinimalActivatorDist(toFile: File, activatorVersion: String): File = ???
-  }
-
+  implicit val timeout = akka.util.Timeout(60 * 1000L, TimeUnit.MILLISECONDS)
   @Before
   def setup() {
     cacheDir = IO.createTemporaryDirectory
@@ -191,71 +130,8 @@ class RemoteTemplateStubTest {
     cacheDir = null
   }
 
-  val template1 = TemplateMetadata(
-    IndexStoredTemplateMetadata(
-      id = "ID-1",
-      timeStamp = 1L,
-      featured = true,
-      usageCount = None,
-      name = "test-template",
-      title = "A Testing Template",
-      description = "A template that tests template existance.",
-      authorName = "Jim Bob",
-      authorLink = "http://example.com/jimbob/",
-      tags = Seq("test", "template"),
-      templateTemplate = false,
-      sourceLink = "http://example.com/source",
-      authorLogo = Some("http://example.com/logo.png"),
-      authorBio = Some("Blah blah blah blah"),
-      authorTwitter = Some("blah"),
-      category = TemplateMetadata.Category.COMPANY,
-      creationTime = TemplateMetadata.LEGACY_CREATION_TIME),
-    locallyCached = true)
-
-  val nonLocalTemplate = TemplateMetadata(
-    IndexStoredTemplateMetadata(
-      id = "ID-2",
-      timeStamp = 1L,
-      featured = false,
-      usageCount = None,
-      name = "test-remote-template",
-      title = "A Testing Template that is not dowloaded",
-      description = "A template that tests template existentialism.",
-      authorName = "Jim Bob",
-      authorLink = "http://example.com/jimbob/",
-      tags = Seq("test", "template"),
-      templateTemplate = true,
-      sourceLink = "http://example.com/source",
-      authorLogo = Some("http://example.com/logo.png"),
-      authorBio = Some("Blah blah blah blah"),
-      authorTwitter = Some("blah"),
-      category = TemplateMetadata.Category.COMPANY,
-      creationTime = TemplateMetadata.LEGACY_CREATION_TIME),
-    locallyCached = false)
-
   val resolvedNonLocalTemplate =
     nonLocalTemplate.copy(locallyCached = true)
-
-  val newNonLocalTemplate = TemplateMetadata(
-    IndexStoredTemplateMetadata(
-      id = "ID-3",
-      timeStamp = 1L,
-      featured = true,
-      usageCount = None,
-      name = "test-updated-template",
-      title = "A NEW FEATURED TEMPLATE",
-      description = "A template that tests template deism.  MONADS.",
-      authorName = "Jim Bob",
-      authorLink = "http://example.com/jimbob/",
-      tags = Seq("test", "template"),
-      templateTemplate = false,
-      sourceLink = "http://example.com/source",
-      authorLogo = Some("http://example.com/logo.png"),
-      authorBio = Some("Blah blah blah blah"),
-      authorTwitter = Some("blah"),
-      category = TemplateMetadata.Category.COMPANY,
-      creationTime = TemplateMetadata.LEGACY_CREATION_TIME),
-    locallyCached = false)
 
   val resolvedNewNonLocalTemplate =
     newNonLocalTemplate.copy(locallyCached = true)

--- a/templates-cache/src/test/scala/activator/cache/RemoteTemplateStubTest.scala
+++ b/templates-cache/src/test/scala/activator/cache/RemoteTemplateStubTest.scala
@@ -7,7 +7,6 @@ package cache
 import java.io.File
 import java.util.concurrent.TimeUnit
 
-import activator.cache.StubRemoteRepository._
 import akka.actor._
 import org.junit.Assert._
 import org.junit._
@@ -20,7 +19,51 @@ class RemoteTemplateStubTest {
   var cacheDir: File = null
   var system: ActorSystem = null
   var cache: TemplateCache = null
+  val stubRemoteRepository =
+    new StubRemoteRepository(
+      template1 = TemplateMetadata(
+        IndexStoredTemplateMetadata(
+          id = "ID-1",
+          timeStamp = 1L,
+          featured = true,
+          usageCount = None,
+          name = "test-template",
+          title = "A Testing Template",
+          description = "A template that tests template existance.",
+          authorName = "Jim Bob",
+          authorLink = "http://example.com/jimbob/",
+          tags = Seq("test", "template"),
+          templateTemplate = false,
+          sourceLink = "http://example.com/source",
+          authorLogo = Some("http://example.com/logo.png"),
+          authorBio = Some("Blah blah blah blah"),
+          authorTwitter = Some("blah"),
+          category = TemplateMetadata.Category.COMPANY,
+          creationTime = TemplateMetadata.LEGACY_CREATION_TIME),
+        locallyCached = true),
+      nonLocalTemplate = TemplateMetadata(
+        IndexStoredTemplateMetadata(
+          id = "ID-2",
+          timeStamp = 1L,
+          featured = false,
+          usageCount = None,
+          name = "test-remote-template",
+          title = "A Testing Template that is not dowloaded",
+          description = "A template that tests template existentialism.",
+          authorName = "Jim Bob",
+          authorLink = "http://example.com/jimbob/",
+          tags = Seq("test", "template"),
+          templateTemplate = true,
+          sourceLink = "http://example.com/source",
+          authorLogo = Some("http://example.com/logo.png"),
+          authorBio = Some("Blah blah blah blah"),
+          authorTwitter = Some("blah"),
+          category = TemplateMetadata.Category.COMPANY,
+          creationTime = TemplateMetadata.LEGACY_CREATION_TIME),
+        locallyCached = false))
+  import stubRemoteRepository._
   implicit val timeout = akka.util.Timeout(60 * 1000L, TimeUnit.MILLISECONDS)
+
   @Before
   def setup() {
     cacheDir = IO.createTemporaryDirectory
@@ -31,7 +74,7 @@ class RemoteTemplateStubTest {
     cache = DefaultTemplateCache(
       actorFactory = system,
       location = cacheDir,
-      remote = StubRemoteRepository)
+      remote = stubRemoteRepository)
   }
 
   @Test

--- a/templates-cache/src/test/scala/activator/cache/StubRemoteRepository.scala
+++ b/templates-cache/src/test/scala/activator/cache/StubRemoteRepository.scala
@@ -1,0 +1,138 @@
+package activator.cache
+
+import java.io.File
+import java.net.URI
+import java.util.UUID
+
+import sbt.IO
+
+object StubRemoteRepository extends RemoteTemplateRepository {
+  val FIRST_INDEX_ID = "FIRST INDEX"
+  val SECOND_INDEX_ID = "SECOND INDEX"
+
+  val template1 = TemplateMetadata(
+    IndexStoredTemplateMetadata(
+      id = "ID-1",
+      timeStamp = 1L,
+      featured = true,
+      usageCount = None,
+      name = "test-template",
+      title = "A Testing Template",
+      description = "A template that tests template existance.",
+      authorName = "Jim Bob",
+      authorLink = "http://example.com/jimbob/",
+      tags = Seq("test", "template"),
+      templateTemplate = false,
+      sourceLink = "http://example.com/source",
+      authorLogo = Some("http://example.com/logo.png"),
+      authorBio = Some("Blah blah blah blah"),
+      authorTwitter = Some("blah"),
+      category = TemplateMetadata.Category.COMPANY,
+      creationTime = TemplateMetadata.LEGACY_CREATION_TIME),
+    locallyCached = true)
+
+  val nonLocalTemplate = TemplateMetadata(
+    IndexStoredTemplateMetadata(
+      id = "ID-2",
+      timeStamp = 1L,
+      featured = false,
+      usageCount = None,
+      name = "test-remote-template",
+      title = "A Testing Template that is not dowloaded",
+      description = "A template that tests template existentialism.",
+      authorName = "Jim Bob",
+      authorLink = "http://example.com/jimbob/",
+      tags = Seq("test", "template"),
+      templateTemplate = true,
+      sourceLink = "http://example.com/source",
+      authorLogo = Some("http://example.com/logo.png"),
+      authorBio = Some("Blah blah blah blah"),
+      authorTwitter = Some("blah"),
+      category = TemplateMetadata.Category.COMPANY,
+      creationTime = TemplateMetadata.LEGACY_CREATION_TIME),
+    locallyCached = false)
+
+  val newNonLocalTemplate = TemplateMetadata(
+    IndexStoredTemplateMetadata(
+      id = "ID-3",
+      timeStamp = 1L,
+      featured = true,
+      usageCount = None,
+      name = "test-updated-template",
+      title = "A NEW FEATURED TEMPLATE",
+      description = "A template that tests template deism.  MONADS.",
+      authorName = "Jim Bob",
+      authorLink = "http://example.com/jimbob/",
+      tags = Seq("test", "template"),
+      templateTemplate = false,
+      sourceLink = "http://example.com/source",
+      authorLogo = Some("http://example.com/logo.png"),
+      authorBio = Some("Blah blah blah blah"),
+      authorTwitter = Some("blah"),
+      category = TemplateMetadata.Category.COMPANY,
+      creationTime = TemplateMetadata.LEGACY_CREATION_TIME),
+    locallyCached = false)
+
+  def resolveIndexProperties(localPropsFile: File): File = {
+    // TODO - implement?
+    localPropsFile
+  }
+  def hasNewIndexProperties(currentHash: String): Boolean =
+    SECOND_INDEX_ID != currentHash
+
+  def resolveLatestIndexHash(): String =
+    SECOND_INDEX_ID
+
+  def ifNewIndexProperties(currentHash: String)(onNewProperties: CacheProperties => Unit): Unit =
+    if (hasNewIndexProperties(currentHash)) {
+      IO.withTemporaryDirectory { tmpDir =>
+        val propsFile = new File(tmpDir, "index.properties")
+        val props = new CacheProperties(propsFile)
+        props.cacheIndexHash = SECOND_INDEX_ID
+        props.save("saved SECOND_INDEX_ID")
+        onNewProperties(props)
+      }
+    }
+
+  // TODO - Actually alter the index and check to see if we have the new one.
+  // Preferable with a new template, not in the existing index.
+  def resolveIndexTo(indexDirOrFile: File, currentHash: String): Unit = {
+    makeIndex(indexDirOrFile)(
+      template1,
+      nonLocalTemplate,
+      newNonLocalTemplate)
+  }
+
+  def resolveTemplateTo(templateId: String, localDir: File): File = {
+    if (nonLocalTemplate.id == templateId || newNonLocalTemplate.id == templateId) {
+      // Fake Resolving a remote template
+      if (!localDir.exists) IO.createDirectory(localDir)
+      IO.write(new File(localDir, "build2.sbt"), """name := "Test2" """)
+      val tutorialDir = new File(localDir, Constants.TUTORIAL_DIR)
+      IO createDirectory tutorialDir
+      IO.write(new File(tutorialDir, "index.html"), "<html></html>")
+    }
+    localDir
+  }
+
+  def templateBundleURI(activatorVersion: String,
+    uuid: UUID,
+    templateName: String): URI = ???
+
+  def templateBundleExists(activatorVersion: String,
+    uuid: UUID,
+    templateName: String): Boolean = ???
+
+  def templateZipURI(uuid: UUID): URI = ???
+
+  def authorLogoURI(uuid: UUID): URI = ???
+
+  def resolveMinimalActivatorDist(toFile: File, activatorVersion: String): File = ???
+
+  def makeIndex(dir: File)(templates: TemplateMetadata*): Unit = {
+    if (dir.exists) IO.delete(dir)
+    val writer = LuceneIndexProvider.write(dir)
+    try templates foreach { t => writer insert t.persistentConfig }
+    finally writer.close()
+  }
+}

--- a/templates-cache/src/test/scala/activator/cache/StubRemoteRepository.scala
+++ b/templates-cache/src/test/scala/activator/cache/StubRemoteRepository.scala
@@ -6,52 +6,11 @@ import java.util.UUID
 
 import sbt.IO
 
-object StubRemoteRepository extends RemoteTemplateRepository {
+class StubRemoteRepository(
+  val template1: TemplateMetadata,
+  val nonLocalTemplate: TemplateMetadata) extends RemoteTemplateRepository {
   val FIRST_INDEX_ID = "FIRST INDEX"
   val SECOND_INDEX_ID = "SECOND INDEX"
-
-  val template1 = TemplateMetadata(
-    IndexStoredTemplateMetadata(
-      id = "ID-1",
-      timeStamp = 1L,
-      featured = true,
-      usageCount = None,
-      name = "test-template",
-      title = "A Testing Template",
-      description = "A template that tests template existance.",
-      authorName = "Jim Bob",
-      authorLink = "http://example.com/jimbob/",
-      tags = Seq("test", "template"),
-      templateTemplate = false,
-      sourceLink = "http://example.com/source",
-      authorLogo = Some("http://example.com/logo.png"),
-      authorBio = Some("Blah blah blah blah"),
-      authorTwitter = Some("blah"),
-      category = TemplateMetadata.Category.COMPANY,
-      creationTime = TemplateMetadata.LEGACY_CREATION_TIME),
-    locallyCached = true)
-
-  val nonLocalTemplate = TemplateMetadata(
-    IndexStoredTemplateMetadata(
-      id = "ID-2",
-      timeStamp = 1L,
-      featured = false,
-      usageCount = None,
-      name = "test-remote-template",
-      title = "A Testing Template that is not dowloaded",
-      description = "A template that tests template existentialism.",
-      authorName = "Jim Bob",
-      authorLink = "http://example.com/jimbob/",
-      tags = Seq("test", "template"),
-      templateTemplate = true,
-      sourceLink = "http://example.com/source",
-      authorLogo = Some("http://example.com/logo.png"),
-      authorBio = Some("Blah blah blah blah"),
-      authorTwitter = Some("blah"),
-      category = TemplateMetadata.Category.COMPANY,
-      creationTime = TemplateMetadata.LEGACY_CREATION_TIME),
-    locallyCached = false)
-
   val newNonLocalTemplate = TemplateMetadata(
     IndexStoredTemplateMetadata(
       id = "ID-3",


### PR DESCRIPTION
Allows users to use their templates from Activator cli by placing their templates in ${activator.template.localrepo}/templates directory. This is done by adding  metadata of  template directories in  ${activator.template.localrepo}/templates to local Lucene index.
